### PR TITLE
feat(U-6962838906): Return Jurisdiction ID and Jurisdiction Name To Front End

### DIFF
--- a/app/src/main/java/app/RootController.java
+++ b/app/src/main/java/app/RootController.java
@@ -18,7 +18,12 @@ import app.dto.discovery.DiscoveryDTO;
 import app.dto.download.DownloadRequestsArgumentsDTO;
 import app.dto.service.ServiceDTO;
 import app.dto.service.ServiceList;
-import app.dto.servicerequest.*;
+import app.dto.servicerequest.GetServiceRequestsDTO;
+import app.dto.servicerequest.PostRequestServiceRequestDTO;
+import app.dto.servicerequest.PostResponseServiceRequestDTO;
+import app.dto.servicerequest.ServiceRequestDTO;
+import app.dto.servicerequest.ServiceRequestList;
+import app.model.jurisdiction.JurisdictionInfoResponse;
 import app.model.service.servicedefinition.ServiceDefinition;
 import app.service.discovery.DiscoveryEndpointService;
 import app.service.jurisdiction.JurisdictionService;
@@ -36,17 +41,23 @@ import io.micronaut.data.model.Pageable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Consumes;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.annotation.RequestBean;
 import io.micronaut.http.server.types.files.StreamedFile;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
-
-import javax.validation.Valid;
 import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Map;
+import javax.validation.Valid;
 
 @Controller("/api")
 @Secured(SecurityRule.IS_ANONYMOUS)
@@ -279,6 +290,13 @@ public class RootController {
     @ExecuteOn(TaskExecutors.IO)
     public StreamedFile downloadServiceRequests(@Valid @RequestBean DownloadRequestsArgumentsDTO requestDTO) throws MalformedURLException {
         return serviceRequestService.getAllServiceRequests(requestDTO);
+    }
+
+    @Get(value =  "/config")
+    @Secured(SecurityRule.IS_AUTHENTICATED)
+    @ExecuteOn(TaskExecutors.IO)
+    public JurisdictionInfoResponse getJurisdictionInfo(@Header("Host") String hostName) {
+        return jurisdictionService.findJurisdictionByHostName(hostName);
     }
 
     private void sanitizeXmlContent(ServiceRequestDTO serviceRequestDTO) {

--- a/app/src/main/java/app/model/jurisdiction/Jurisdiction.java
+++ b/app/src/main/java/app/model/jurisdiction/Jurisdiction.java
@@ -30,6 +30,12 @@ public class Jurisdiction {
     @Id
     private String id;
 
+    private String name;
+
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true, mappedBy = "jurisdiction")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Set<RemoteHost> remoteHosts = new HashSet<>();
+
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true, mappedBy = "jurisdiction")
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Set<Service> services = new HashSet<>();
@@ -40,6 +46,12 @@ public class Jurisdiction {
 
     public Jurisdiction(String id) {
         this.id = id;
+    }
+
+    public Jurisdiction(String id, String name, RemoteHost remoteHost) {
+        this.id = id;
+        this.name = name;
+        remoteHosts.add(remoteHost);
     }
 
     public Jurisdiction() {}
@@ -67,4 +79,21 @@ public class Jurisdiction {
     public void setServiceRequests(Set<ServiceRequest> serviceRequests) {
         this.serviceRequests = serviceRequests;
     }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<RemoteHost> getRemoteHosts() {
+        return remoteHosts;
+    }
+
+    public void setRemoteHosts(Set<RemoteHost> remoteHosts) {
+        this.remoteHosts = remoteHosts;
+    }
+
 }

--- a/app/src/main/java/app/model/jurisdiction/JurisdictionInfoResponse.java
+++ b/app/src/main/java/app/model/jurisdiction/JurisdictionInfoResponse.java
@@ -1,0 +1,33 @@
+package app.model.jurisdiction;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class JurisdictionInfoResponse {
+  private String id;
+  private String name;
+
+  public JurisdictionInfoResponse() {
+  }
+
+  public JurisdictionInfoResponse(String id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/app/src/main/java/app/model/jurisdiction/JurisdictionRepository.java
+++ b/app/src/main/java/app/model/jurisdiction/JurisdictionRepository.java
@@ -16,7 +16,10 @@ package app.model.jurisdiction;
 
 import io.micronaut.data.annotation.Repository;
 import io.micronaut.data.repository.PageableRepository;
+import java.util.Optional;
 
 @Repository
 public interface JurisdictionRepository extends PageableRepository<Jurisdiction, String> {
+
+  Optional<Jurisdiction> findByRemoteHostsNameEquals(String hosts);
 }

--- a/app/src/main/java/app/model/jurisdiction/RemoteHost.java
+++ b/app/src/main/java/app/model/jurisdiction/RemoteHost.java
@@ -1,0 +1,55 @@
+package app.model.jurisdiction;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "remote_hosts")
+public class RemoteHost {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String name;
+
+  @ManyToOne
+  @JoinColumn(name = "jurisdiction_id")
+  private Jurisdiction jurisdiction;
+
+  public RemoteHost() {
+  }
+
+  public RemoteHost(String name) {
+    this.name = name;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Jurisdiction getJurisdiction() {
+    return jurisdiction;
+  }
+
+  public void setJurisdiction(Jurisdiction jurisdiction) {
+    this.jurisdiction = jurisdiction;
+  }
+}

--- a/app/src/main/java/app/service/jurisdiction/JurisdictionService.java
+++ b/app/src/main/java/app/service/jurisdiction/JurisdictionService.java
@@ -14,13 +14,13 @@
 
 package app.service.jurisdiction;
 
+import app.model.jurisdiction.JurisdictionInfoResponse;
 import app.model.jurisdiction.JurisdictionRepository;
 import jakarta.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class JurisdictionService {
@@ -55,5 +55,11 @@ public class JurisdictionService {
         }
 
         return List.of();
+    }
+
+    public JurisdictionInfoResponse findJurisdictionByHostName(String hostName) {
+        return jurisdictionRepository.findByRemoteHostsNameEquals(hostName)
+            .map(jurisdiction -> new JurisdictionInfoResponse(jurisdiction.getId(), jurisdiction.getName()))
+            .orElse(null);
     }
 }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -70,6 +70,10 @@ jpa:
       hibernate:
         hbm2ddl:
           auto: ${LIBRE311_AUTO_SCHEMA_GEN:update}
+#        show_sql: true
+#        format_sql: true
+#        use_sql_comments: true
+#        type: trace
 netty:
   default:
     allocator:

--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -9,7 +9,8 @@
         </encoder>
     </appender>
 
-<!--    <logger name="io.micronaut.http.client" level="TRACE"/>-->
+    <!--    <logger name="io.micronaut.http.client" level="TRACE"/>-->
+<!--        <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE"/>-->
 
     <root level="info">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Implemented new RemoteHost entity to model a many-to-one relationship between jurisdictions and hosts. Updated Jurisdiction model to include a set of RemoteHost entities, and modified associated service methods and tests accordingly.