### PR TITLE
Removed Take Photo button from mobile view

### DIFF
--- a/frontend/src/lib/components/CreateServiceRequest/UploadFile.svelte
+++ b/frontend/src/lib/components/CreateServiceRequest/UploadFile.svelte
@@ -75,17 +75,6 @@
 			<div class="grid grid-rows-4 gap-3">
 				<input
 					type="file"
-					id="actual-btn"
-					accept="image/*"
-					capture="environment"
-					hidden
-					bind:this={input}
-					on:change={onChange}
-				/>
-				<label for="actual-btn">{messages['photo']['take_photo']}</label>
-
-				<input
-					type="file"
 					name="photo"
 					id="camera-roll-btn"
 					accept="image/*"
@@ -93,7 +82,7 @@
 					bind:this={input}
 					on:change={onChange}
 				/>
-				<label for="camera-roll-btn">{messages['photo']['camera_roll']}</label>
+				<label for="camera-roll-btn">{messages['photo']['upload']}</label>
 
 				<Button
 					type="link"


### PR DESCRIPTION
Hitting the "Camera Roll" button allows the taking of a photo, which makes the "Take a Photo" button redundant, so now it's gone. Turns out the best solutions are often the simplest ones.