### PR TITLE
BUGFIX: Narrow service cards

### DIFF
--- a/frontend/src/lib/components/ServiceRequestDetails.svelte
+++ b/frontend/src/lib/components/ServiceRequestDetails.svelte
@@ -25,7 +25,7 @@
 </script>
 
 <div class="flex h-full">
-	<Card class="m-2">
+	<Card class="m-2 w-full">
 		<div class="flex h-full w-full flex-col" slot="content">
 			<div class="m-2 flex-grow">
 				<div class="flow-root">

--- a/frontend/src/lib/components/ServiceRequestUpdate.svelte
+++ b/frontend/src/lib/components/ServiceRequestUpdate.svelte
@@ -142,7 +142,7 @@
 </script>
 
 <div class="flex h-full">
-	<Card class="m-2">
+	<Card class="m-2 w-full">
 		<div class="flex h-full w-full flex-col" slot="content">
 			<div class="m-2 flex-grow">
 				<div class="flow-root">


### PR DESCRIPTION
If a service card doesn't have enough text to fill the width of the left column, the cards would not fill the space in full. Now they do.