### PR TITLE
attempting to turn of user scaling

### DIFF
--- a/frontend/src/routes/issue/create/+page.svelte
+++ b/frontend/src/routes/issue/create/+page.svelte
@@ -91,7 +91,7 @@
 </script>
 
 <svelte:head>
-	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 </svelte:head>
 
 <CreateServiceRequestLayout {step}>


### PR DESCRIPTION
Testing this out.  I think this will prevent iphone users from having the **browser** zoom in the map view.  Thus preventing the annoying iphone zoom feature/bug.

https://stackoverflow.com/questions/6397748/whats-the-point-of-meta-viewport-user-scalable-no-in-the-google-maps-api