### PR TITLE
Add non-null validations for Service Definition Attributes when creating

### DIFF
--- a/app/src/main/java/app/dto/servicedefinition/CreateServiceDefinitionAttributeDTO.java
+++ b/app/src/main/java/app/dto/servicedefinition/CreateServiceDefinitionAttributeDTO.java
@@ -47,9 +47,46 @@ public class CreateServiceDefinitionAttributeDTO extends UpdateServiceDefinition
         return super.getDatatype();
     }
 
-    @NotBlank
+    @NotNull
     @Override
     public void setDatatype(AttributeDataType datatype) {
         super.setDatatype(datatype);
+    }
+
+
+    @NotNull
+    @Override
+    public Boolean isVariable() {
+        return super.isVariable();
+    }
+
+    @NotNull
+    @Override
+    public void setVariable(Boolean variable) {
+        super.setVariable(variable);
+    }
+
+    @NotNull
+    @Override
+    public Boolean isRequired() {
+        return super.isRequired();
+    }
+
+    @NotNull
+    @Override
+    public void setRequired(Boolean required) {
+        super.setRequired(required);
+    }
+
+    @NotNull
+    @Override
+    public Integer getAttributeOrder() {
+        return super.getAttributeOrder();
+    }
+
+    @NotNull
+    @Override
+    public void setAttributeOrder(Integer attributeOrder) {
+        super.setAttributeOrder(attributeOrder);
     }
 }


### PR DESCRIPTION
When creating/adding a Service Attribute, `order`, `required`, and `variable` should be declared.