### PR TITLE
Service request indent enhancement

### DIFF
--- a/frontend/src/lib/components/ServiceRequest.svelte
+++ b/frontend/src/lib/components/ServiceRequest.svelte
@@ -199,4 +199,7 @@
 		background-size: cover;
 		border-radius: 10px;
 	}
+	.mb-1 p{
+		text-indent: .5rem;
+	}
 </style>

--- a/frontend/src/lib/components/ServiceRequest.svelte
+++ b/frontend/src/lib/components/ServiceRequest.svelte
@@ -199,7 +199,7 @@
 		background-size: cover;
 		border-radius: 10px;
 	}
-	.mb-1 p{
+	.mb-1 p {
 		text-indent: .5rem;
 	}
 </style>

--- a/frontend/src/lib/components/ServiceRequestDetails.svelte
+++ b/frontend/src/lib/components/ServiceRequestDetails.svelte
@@ -119,4 +119,7 @@
 		background-size: cover;
 		border-radius: 10px;
 	}
+	.mb-1 p{
+		text-indent: .5rem;
+	}
 </style>

--- a/frontend/src/lib/components/ServiceRequestDetails.svelte
+++ b/frontend/src/lib/components/ServiceRequestDetails.svelte
@@ -119,7 +119,7 @@
 		background-size: cover;
 		border-radius: 10px;
 	}
-	.mb-1 p{
+	.mb-1 p {
 		text-indent: .5rem;
 	}
 </style>


### PR DESCRIPTION
I added a text indent to all paragraphs nested in mb-1 classed div ( this leaves the address alone). 

This slight indent improves the readability by separating the header and paragraph visually without compromising the layout.

This is a non issue for the service request preview. 