### PR TITLE
Updating requests now sends user back to the right page

### DIFF
--- a/frontend/src/lib/components/ServiceRequest.svelte
+++ b/frontend/src/lib/components/ServiceRequest.svelte
@@ -45,7 +45,7 @@
 				description: 'Your service request has been updated'
 			});
 
-			goto(`/issues/table`);
+			goto(back);
 		} catch (error) {
 			alertError(error);
 		}


### PR DESCRIPTION
When a request is updated, the page should now jump to whatever page the issue was on (i.e., if an issue is on page 2, the user will be returned to page 2 on update, as opposed to the first page, which was the initial behavior).