### PR TITLE
Libre311 Accessibility Issue #4

### DIFF
--- a/frontend/src/lib/components/Pagination.svelte
+++ b/frontend/src/lib/components/Pagination.svelte
@@ -28,7 +28,7 @@
 			type={prevPage ? 'text' : 'ghost'}
 			disabled={!prevPage}
 			shape="circle"
-			aria-label="previous set"
+			title="Previous Set"
 			on:click={scrollDispatch}
 		>
 			<ChevronLeft slot="icon" />
@@ -38,7 +38,7 @@
 			type={nextPage ? 'text' : 'ghost'}
 			disabled={!nextPage}
 			shape="circle"
-			aria-label="next set"
+			title="Next Set"
 			on:click={scrollDispatch}
 		>
 			<ChevronRight slot="icon" />


### PR DESCRIPTION
< button and > link to navigate to previous/next set of requests have no aria-label

I did the equivalent with "title". Both narrator and nvda would say the terms plus we get the tooltip.