### PR TITLE
Libre311 Accessibility Issue #4

### DIFF
--- a/frontend/src/lib/components/Pagination.svelte
+++ b/frontend/src/lib/components/Pagination.svelte
@@ -29,6 +29,7 @@
 			disabled={!prevPage}
 			shape="circle"
 			title="Previous Set"
+			aria-label="Previous Set"
 			on:click={scrollDispatch}
 		>
 			<ChevronLeft slot="icon" />
@@ -39,6 +40,7 @@
 			disabled={!nextPage}
 			shape="circle"
 			title="Next Set"
+			aria-label="Next Set"
 			on:click={scrollDispatch}
 		>
 			<ChevronRight slot="icon" />


### PR DESCRIPTION
< button and > link to navigate to previous/next set of requests have no aria-label

I did the equivalent with "title". Both narrator and nvda would say the terms plus we get the tooltip.