### PR TITLE
Autoclose for toast with timeout for notifications

### DIFF
--- a/frontend/src/lib/context/Libre311AlertStore.ts
+++ b/frontend/src/lib/context/Libre311AlertStore.ts
@@ -44,9 +44,7 @@ export function createAlertStore(): AlertStore {
 		clearAutoDismiss();
 		const duration = getEffectiveDuration(alert);
 		if (duration !== null) {
-			autoDismissTimeout = setTimeout(() => {
-				close();
-			}, duration);
+			autoDismissTimeout = setTimeout(close, duration);
 		}
 	}
 


### PR DESCRIPTION
Success and info alerts now auto-dismiss after 4 seconds by default 
Error and warning alerts still require manual close (users need time to read them) 
Close button remains so users can dismiss early if they want 
Existing code works without changes - no need to update any alert() calls